### PR TITLE
Add release-plan.yaml

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -1,0 +1,57 @@
+# CAMARA Release Plan
+# This file declares release intentions for this repository.
+# It replaces manual wiki tracking with automated tooling.
+#
+# Workflow: Update this file → CI validates → Trigger release when ready
+# Docs: https://github.com/camaraproject/ReleaseManagement
+
+repository:
+  # How this repository participates in CAMARA releases
+  # Options: none | independent | meta-release
+  release_track: meta-release
+  # Meta-release participation (update for next cycle when planning)
+  meta_release: Fall25
+
+  # Current/last release tag — update for your next release:
+  # - New release cycle (increment first number, reset second to 1)
+  # - Progression in same cycle (increment second number)
+  target_release_tag: r3.2
+
+  # Release type being prepared (must be set before release can be triggered)
+  # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
+  target_release_type: none
+
+# Dependencies on Commonalities and ICM releases
+# Update per ReleaseManagement requirements for each release cycle
+dependencies:
+  commonalities_release: r3.4
+  identity_consent_management_release: r3.3
+
+# APIs in this repository
+# - api_name: kebab-case identifier (must be filename in code/API_definitions/)
+# - target_api_status: draft (no file yet) | alpha | rc | public
+apis:
+  - api_name: qos-profiles
+    target_api_version: 1.1.0
+    target_api_status: public
+    main_contacts:
+      - hdamker
+      - eric-murray
+      - RandyLevensalor
+      - jlurien
+  - api_name: qos-provisioning
+    target_api_version: 0.3.0
+    target_api_status: public
+    main_contacts:
+      - hdamker
+      - eric-murray
+      - RandyLevensalor
+      - jlurien
+  - api_name: quality-on-demand
+    target_api_version: 1.1.0
+    target_api_status: public
+    main_contacts:
+      - hdamker
+      - eric-murray
+      - RandyLevensalor
+      - jlurien


### PR DESCRIPTION
## Summary
- Add initial release-plan.yaml for this repository
- Tests validation workflow from hdamker/tooling@release-plan-validation

## Test plan
- [ ] Verify release-plan.yaml validation runs
- [ ] Verify separate check status appears in PR UI
- [ ] Verify MegaLinter runs after validation