### PR TITLE
Plan r5.1 alpha release (Spring27)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,46 +10,46 @@ repository:
   # Options: none | independent | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Fall26
+  meta_release: Spring27
 
   # Current/last release tag — update for your next release:
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r4.3
+  target_release_tag: r5.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: public-release
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.1
+  identity_consent_management_release: r4.1
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: qos-profiles
-    target_api_version: 1.2.0
-    target_api_status: public
+    target_api_version: 1.3.0
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: qos-provisioning
-    target_api_version: 0.4.0
-    target_api_status: public
+    target_api_version: 0.5.0
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: quality-on-demand
-    target_api_version: 1.2.0
-    target_api_status: public
+    target_api_version: 1.3.0
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray


### PR DESCRIPTION
Update release-plan.yaml for r5.1 alpha release targeting Spring27 meta-release.

Changes:
- target_release_tag: r4.3 → r5.1
- target_release_type: public-release → pre-release-alpha
- meta_release: Fall26 → Spring27
- API versions bumped for alpha