### PR TITLE
Update release-plan.yaml for r6.2 alpha

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -15,7 +15,7 @@ repository:
   # Current/last release tag — update for your next release:
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r6.1
+  target_release_tag: r6.2
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
@@ -32,24 +32,27 @@ dependencies:
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: qos-profiles
-    target_api_version: 1.3.0
-    target_api_status: public
+    target_api_version: 1.4.0
+    target_api_status: alpha
+    # IMP-012 test: r4.1 has 1.2.0-alpha.1 (v1alpha1) → must get .2
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: qos-provisioning
-    target_api_version: 0.5.0
-    target_api_status: public
+    target_api_version: 0.6.0
+    target_api_status: alpha
+    # IMP-012 test: r4.1 has 0.4.0-alpha.1 (v0.4alpha1) → different minor, gets .1
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: quality-on-demand
-    target_api_version: 2.0.0
+    target_api_version: 2.1.0
     target_api_status: alpha
+    # IMP-012 test: r6.1 has 2.0.0-alpha.1 (v2alpha1) → must get .2
     main_contacts:
       - hdamker
       - eric-murray


### PR DESCRIPTION
## Summary
Update release plan to target r6.2 alpha with version bumps designed to test IMP-012 (URL-namespace extension uniqueness).

### Expected extension assignments (with fix)
| API | Target | Prior collision source | Expected version | URL |
|-----|--------|----------------------|-----------------|-----|
| qos-profiles | 1.4.0 alpha | r4.1: 1.2.0-alpha.1 (v1alpha1) | **1.4.0-alpha.2** | v1alpha2 |
| quality-on-demand | 2.1.0 alpha | r6.1: 2.0.0-alpha.1 (v2alpha1) | **2.1.0-alpha.2** | v2alpha2 |
| qos-provisioning | 0.6.0 alpha | r4.1: 0.4.0-alpha.1 (v0.4alpha1) | **0.6.0-alpha.1** | v0.6alpha1 |