### PR TITLE
Plan release r7.1 (alpha)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -15,44 +15,41 @@ repository:
   # Current/last release tag — update for your next release:
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r6.3
+  target_release_tag: r7.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.1
-  identity_consent_management_release: r4.1
+  commonalities_release: r5.1
+  identity_consent_management_release: r5.1
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: qos-profiles
-    target_api_version: 1.4.0
-    target_api_status: rc
-    # IMP-012 test: r4.1 has 1.2.0-alpha.1 (v1alpha1) → must get .2
+    target_api_version: 1.5.0
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: qos-provisioning
-    target_api_version: 0.6.0
-    target_api_status: rc
-    # IMP-012 test: r4.1 has 0.4.0-alpha.1 (v0.4alpha1) → different minor, gets .1
+    target_api_version: 1.0.0
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: quality-on-demand
-    target_api_version: 2.1.0
-    target_api_status: rc
-    # IMP-012 test: r6.1 has 2.0.0-alpha.1 (v2alpha1) → must get .2
+    target_api_version: 2.2.0
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray


### PR DESCRIPTION
## What type of PR is this?

Release plan update for regression testing.

## What does this PR do?

Updates release-plan.yaml for a new release cycle:
- Target: r7.1 (pre-release-alpha)
- qos-profiles: 1.5.0-alpha
- qos-provisioning: 1.0.0-alpha
- quality-on-demand: 2.2.0-alpha
- Dependencies: Commonalities r5.1, ICM r5.1

## Purpose

Regression test of release automation after upstream migration to
camaraproject/tooling@release-automation (PR #67 + #68 merged).