### PR TITLE
test: pr_validation without release-plan.yaml changes (tooling#127)

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -1,4 +1,5 @@
 openapi: 3.0.3
+# Test: pr_validation result step without release-plan.yaml changes (tooling#127)
 info:
   title: QoS Profiles
   description: |


### PR DESCRIPTION
Test PR for tooling#127 fix. No release-plan.yaml changes — expect 'release-plan.yaml not modified, validation skipped' notice.