### PR TITLE
test: pr_validation with valid release-plan.yaml change (tooling#127)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -15,7 +15,7 @@ repository:
   # Current/last release tag — update for your next release:
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r7.2
+  target_release_tag: r7.3
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release


### PR DESCRIPTION
Test PR for tooling#127 fix. Valid release-plan.yaml change (tag bump) — expect 'release-plan.yaml validation passed' notice, no warning.