### PR TITLE
test(validation): pin QoD caller to history branch

### DIFF
--- a/.github/workflows/camara-validation.yml
+++ b/.github/workflows/camara-validation.yml
@@ -30,8 +30,8 @@ permissions:
 
 jobs:
   validation:
-    uses: hdamker/tooling/.github/workflows/validation.yml@fix/gplint-gherkin-lint
-    # Fork test of the GPLint migration. Do not set tooling_ref_override here:
+    uses: hdamker/tooling/.github/workflows/validation.yml@feat/release-plan-published-history-validation
+    # Fork test of release-plan published-history validation. Do not set tooling_ref_override here:
     # the override path checks out camaraproject/tooling, while the OIDC path
     # resolves the tooling checkout to the called workflow SHA in hdamker/tooling.
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Pins the CAMARA validation caller workflow to hdamker/tooling branch feat/release-plan-published-history-validation so follow-up release-plan validation test PRs exercise the new checks.

#### Which issue(s) this PR fixes:

Related to camaraproject/tooling#232

#### Special notes for reviewers:

Merge this before opening the release-plan-only test PRs, otherwise those PRs include the workflow pin change and can trigger release-plan exclusivity instead of the intended finding.

#### Changelog input

```
release-note
NONE
```

#### Additional documentation 

This section can be blank.

```
docs
```
