### PR TITLE
test(validation): trigger duplicate api_name finding

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -39,6 +39,14 @@ apis:
       - eric-murray
       - RandyLevensalor
       - jlurien
+  - api_name: qos-profiles
+    target_api_version: 1.2.0
+    target_api_status: rc
+    main_contacts:
+      - hdamker
+      - eric-murray
+      - RandyLevensalor
+      - jlurien
   - api_name: qos-provisioning
     target_api_version: 0.4.0
     target_api_status: rc


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Creates a release-plan-only validation test case for the P-034 duplicate api_name rule by adding a second qos-profiles entry to release-plan.yaml.

#### Which issue(s) this PR fixes:

Related to camaraproject/tooling#232

#### Special notes for reviewers:

This PR is expected to fail CAMARA Validation with a duplicate api_name finding.

#### Changelog input

```
release-note
NONE
```

#### Additional documentation 

This section can be blank.

```
docs
```
