### PR TITLE
test(validation): guard public release after alpha history

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -19,7 +19,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: public-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -33,7 +33,7 @@ dependencies:
 apis:
   - api_name: qos-profiles
     target_api_version: 1.2.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - hdamker
       - eric-murray
@@ -41,7 +41,7 @@ apis:
       - jlurien
   - api_name: qos-provisioning
     target_api_version: 0.4.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - hdamker
       - eric-murray
@@ -49,7 +49,7 @@ apis:
       - jlurien
   - api_name: quality-on-demand
     target_api_version: 1.2.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - hdamker
       - eric-murray


### PR DESCRIPTION
#### What type of PR is this?

tests


#### What this PR does / why we need it:

Exercises the release-plan history case where API versions previously published as alpha are now planned for a public release with the same base versions.

CAMARA Validation should not report `P-035` for this release-plan state. Releasing `1.2.0-alpha.1` later as `1.2.0` public is valid release progression, not a no-new-content condition.


#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

This PR may still show unrelated existing repository validation findings. The regression expectation is specifically that `P-035` must not be present once the pinned tooling branch contains the status-aware history fix.


#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.



```
docs
```
