### PR TITLE
test(validation): trigger P-035 stale alpha plan

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -19,7 +19,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: public-release
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -19,7 +19,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: public-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -32,24 +32,24 @@ dependencies:
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: qos-profiles
-    target_api_version: 1.2.0
-    target_api_status: rc
+    target_api_version: 1.1.0
+    target_api_status: public
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: qos-provisioning
-    target_api_version: 0.4.0
-    target_api_status: rc
+    target_api_version: 0.3.0
+    target_api_status: public
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: quality-on-demand
-    target_api_version: 1.2.0
-    target_api_status: rc
+    target_api_version: 1.1.0
+    target_api_status: public
     main_contacts:
       - hdamker
       - eric-murray


### PR DESCRIPTION
#### What type of PR is this?

tests


#### What this PR does / why we need it:

Exercises the release-plan history case where the repository release type is changed to `pre-release-alpha`, but every API target still repeats a version/status pair already published in release `r3.2`.

CAMARA Validation should report the repository-level `P-035` stale-cohort finding because the release plan does not declare any new API publication.


#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

This PR is a validation trigger branch. The expected signal is a `P-035` finding on `release-plan.yaml` with the stale release-content message, not the per-API terminal-status-lock message.


#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.



```
docs
```
