### PR TITLE
test(validation): trigger P-036 published API status

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -19,7 +19,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -33,7 +33,7 @@ dependencies:
 apis:
   - api_name: qos-profiles
     target_api_version: 1.2.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray
@@ -41,15 +41,15 @@ apis:
       - jlurien
   - api_name: qos-provisioning
     target_api_version: 0.4.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray
       - RandyLevensalor
       - jlurien
   - api_name: quality-on-demand
-    target_api_version: 1.2.0
-    target_api_status: rc
+    target_api_version: 1.1.0
+    target_api_status: alpha
     main_contacts:
       - hdamker
       - eric-murray


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Creates a release-plan-only negative test for P-036. The plan is a pre-release-alpha shape, keeps two APIs at the current target versions, and sets quality-on-demand to version 1.1.0 with target_api_status: alpha.

That API version was already published as public, so CAMARA Validation should report P-036 for quality-on-demand.

#### Which issue(s) this PR fixes:

Related to https://github.com/camaraproject/tooling/issues/232

#### Special notes for reviewers:

Expected validation signal: P-036 on release-plan.yaml for quality-on-demand.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

```
docs
NONE
```