### PR TITLE
test(validation): trigger P-040 component-renaming conflict

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -821,6 +821,17 @@ components:
                 code: TOO_MANY_REQUESTS
                 message: Rate limit reached.
 
+    TestP040ConflictProbe:
+      description: >-
+        Test-only response, not wired to any endpoint. References the common
+        ErrorInfo schema by external $ref, which collides with this file's own
+        local ErrorInfo (different content) — exercises the P-040
+        component-renaming-conflict check. This PR is never merged.
+      content:
+        application/json:
+          schema:
+            $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
+
   examples:
     LIST_OF_QOS_PROFILES:
       summary: A list of QoS profiles with a single entry


### PR DESCRIPTION
Adds a test-only, unused response (`TestP040ConflictProbe`) to `qos-profiles.yaml` that references the common `ErrorInfo` schema by external `$ref`. It collides by name with this file's own local `ErrorInfo`, which has drifted from the common definition (missing `format`/`minimum`/`maximum`/`maxLength` constraints) — exercising the real P-040 bundler component-renaming-conflict check end-to-end through the actual reusable-workflow path, not just pytest.

Never intended to merge.
